### PR TITLE
mybatis toolbox: Upgrade mybatis version

### DIFF
--- a/just-mybatis-toolbox/build.gradle
+++ b/just-mybatis-toolbox/build.gradle
@@ -1,7 +1,7 @@
 description 'Just Java Mybatis Toolbox - common mybatis tools and utilities missing in mybatis library'
 
 dependencies {
-    compile('org.mybatis:mybatis:3.4.6')
+    compile('org.mybatis:mybatis:3.5.4')
     compile project(':just-java-toolbox')
 
     testCompile project(':just-java-test-toolbox')

--- a/just-mybatis-toolbox/src/main/java/de/justsoftware/toolbox/mybatis/type/LongBasedTypeHandler.java
+++ b/just-mybatis-toolbox/src/main/java/de/justsoftware/toolbox/mybatis/type/LongBasedTypeHandler.java
@@ -40,17 +40,28 @@ public class LongBasedTypeHandler<ID> extends BaseTypeHandler<ID> {
 
     @Override
     public ID getNullableResult(final ResultSet rs, final String columnName) throws SQLException {
-        return _fromLong.apply(rs.getLong(columnName));
+        return getNullableResult(rs.getLong(columnName), rs.wasNull());
     }
 
     @Override
     public ID getNullableResult(final ResultSet rs, final int columnIndex) throws SQLException {
-        return _fromLong.apply(rs.getLong(columnIndex));
+        return getNullableResult(rs.getLong(columnIndex), rs.wasNull());
     }
 
     @Override
     public ID getNullableResult(final CallableStatement cs, final int columnIndex) throws SQLException {
-        return _fromLong.apply(cs.getLong(columnIndex));
+        return getNullableResult(cs.getLong(columnIndex), cs.wasNull());
     }
+
+    /**
+     * As we use {@link ResultSet#getLong} and {@link CallableStatement#getLong} we retrieve 0 if the
+     * value in DB was null. Therefore {@link ResultSet#wasNull()} and {@link CallableStatement#wasNull()} have to be
+     * used to determine a null value.
+     * @param value the value retrieved by  {@link ResultSet#getLong} or {@link CallableStatement#getLong}
+     * @param wasNull the value retrieved by {@link ResultSet#wasNull()} or {@link CallableStatement#wasNull()}
+     */
+   private ID getNullableResult(long value, boolean wasNull) {
+        return wasNull ? null : _fromLong.apply(value);
+   }
 
 }

--- a/just-mybatis-toolbox/src/main/java/de/justsoftware/toolbox/mybatis/type/common/BooleanTypeHandler.java
+++ b/just-mybatis-toolbox/src/main/java/de/justsoftware/toolbox/mybatis/type/common/BooleanTypeHandler.java
@@ -43,22 +43,22 @@ public class BooleanTypeHandler extends AbstractDriverSpecificTypeHandler<Boolea
 
     @Override
     protected Boolean getNullableResultPostgres(final ResultSet rs, final String columnName) throws SQLException {
-        return getNullableResultPostgres(rs.getBoolean(columnName));
+        return getNullableResultPostgres(rs.getBoolean(columnName), rs.wasNull());
     }
 
     @Nonnull
-    private static Boolean getNullableResultPostgres(final boolean v) {
-        return Boolean.valueOf(v);
+    private static Boolean getNullableResultPostgres(final boolean value, final boolean wasNull) {
+        return Boolean.valueOf(value);
     }
 
     @Override
     protected Boolean getNullableResultPostgres(final ResultSet rs, final int columnIndex) throws SQLException {
-        return getNullableResultPostgres(rs.getBoolean(columnIndex));
+        return getNullableResultPostgres(rs.getBoolean(columnIndex), rs.wasNull());
     }
 
     @Override
     protected Boolean getNullableResultPostgres(final CallableStatement cs, final int columnIndex) throws SQLException {
-        return getNullableResultPostgres(cs.getBoolean(columnIndex));
+        return getNullableResultPostgres(cs.getBoolean(columnIndex), cs.wasNull());
     }
 
     @Override


### PR DESCRIPTION
Upgrade to mybatis 3.5.4 which is also referenced by newest mybatis-spring-boot-starter version.

There was a major change in mybatis 3.5.x in class org.apache.ibatis.type.BaseTypeHandler<T>:

>   Since 3.5.0, This class never call the ResultSet.wasNull() and
>   CallableStatement.wasNull() method for handling the SQL NULL value.
>   In other words, null value handling should be performed on subclass.

(see: https://mybatis.org/mybatis-3/ja/apidocs/org/apache/ibatis/type/BaseTypeHandler.html)

So now all custom type handlers using mehtods on ResultSet or
CallableStatement that cannot return null (e.g. getLong or getBoolean) now
check the wasNull methods in its implementation.

Change-Id: I2a57a768ba1dd07949475dedf5a0aea728400da8