### PR TITLE
Mockito & Hamcrest update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     group 'de.justsoftware.toolbox'
 
     dependencies {
-        testImplementation 'org.mockito:mockito-core:1.10.19'
-        testImplementation 'org.hamcrest:hamcrest-library:1.3'
+        testImplementation 'org.mockito:mockito-core:3.11.2'
+        testImplementation 'org.hamcrest:hamcrest:2.2'
         testImplementation('org.testng:testng:6.9.9') {
             exclude group: 'junit'
         }

--- a/just-java-test-toolbox/build.gradle
+++ b/just-java-test-toolbox/build.gradle
@@ -3,8 +3,8 @@ description 'Just Java Test Toolbox - common java test tools and utilities missi
 dependencies {
     implementation 'com.google.guava:guava:23.2-jre'
     implementation 'joda-time:joda-time:2.9.9'
-    implementation 'org.mockito:mockito-core:1.10.19'
-    implementation 'org.hamcrest:hamcrest-library:1.3'
+    implementation 'org.mockito:mockito-core:3.11.2'
+    implementation 'org.hamcrest:hamcrest:2.2'
 
     implementation project(':just-java-toolbox')
 }

--- a/just-java-test-toolbox/src/main/java/de/justsoftware/toolbox/hamcrest/HamcrestMatchers.java
+++ b/just-java-test-toolbox/src/main/java/de/justsoftware/toolbox/hamcrest/HamcrestMatchers.java
@@ -34,7 +34,7 @@ public class HamcrestMatchers {
     @Nonnull
     public static <T> Matcher<Iterable<T>> sameIterable(final Function<T, Matcher<? super T>> matcherFunction,
             final Iterable<? extends T> expected) {
-        return new TypeSafeDiagnosingMatcher<Iterable<T>>() {
+        return new TypeSafeDiagnosingMatcher<>() {
             private final ImmutableList<Matcher<? super T>> _matchers =
                     FluentIterable.from(expected).transform(matcherFunction).toList();
 
@@ -73,7 +73,7 @@ public class HamcrestMatchers {
     @Nonnull
     public static <K, V> Matcher<Map<K, V>> sameMap(final Function<V, Matcher<? super V>> valueMatcherFunction,
             final Map<K, V> expected) {
-        return new TypeSafeDiagnosingMatcher<Map<K, V>>() {
+        return new TypeSafeDiagnosingMatcher<>() {
 
             private final ImmutableMap<K, Matcher<? super V>> _matchers =
                     ImmutableMap.copyOf(Maps.transformValues(expected, valueMatcherFunction));
@@ -112,7 +112,7 @@ public class HamcrestMatchers {
     @Nonnull
     public static <K, V> Matcher<Multimap<K, V>> sameMultimap(final Function<V, Matcher<? super V>> valueMatcherFunction,
             final Multimap<K, V> expected) {
-        return new TypeSafeDiagnosingMatcher<Multimap<K, V>>() {
+        return new TypeSafeDiagnosingMatcher<>() {
 
             @Override
             public void describeTo(final Description description) {

--- a/just-java-test-toolbox/src/main/java/de/justsoftware/toolbox/mockito/MockitoAnswers.java
+++ b/just-java-test-toolbox/src/main/java/de/justsoftware/toolbox/mockito/MockitoAnswers.java
@@ -52,7 +52,7 @@ public enum MockitoAnswers implements Answer<Object> {
     @Nonnull
     private static <K> ImmutableSet<K> argumentAsSet(final InvocationOnMock invocation) {
         @SuppressWarnings("unchecked")
-        final Iterable<K> keys = invocation.getArgumentAt(0, Iterable.class);
+        final Iterable<K> keys = invocation.getArgument(0);
         // keys is null when Mockito.any() is passed as argument
         if (keys == null) {
             return ImmutableSet.of();
@@ -63,7 +63,7 @@ public enum MockitoAnswers implements Answer<Object> {
     @Nonnull
     private static <K, V> ImmutableSetMultimap<K, V> argAsMultimap(final InvocationOnMock invocation) {
         @SuppressWarnings("unchecked")
-        final Multimap<K, V> keys = invocation.getArgumentAt(0, Multimap.class);
+        final Multimap<K, V> keys = invocation.getArgument(0);
         // keys is null when Mockito.any() is passed as argument
         if (keys == null) {
             return ImmutableSetMultimap.of();

--- a/just-java-test-toolbox/src/main/java/de/justsoftware/toolbox/mockito/Mocks.java
+++ b/just-java-test-toolbox/src/main/java/de/justsoftware/toolbox/mockito/Mocks.java
@@ -9,7 +9,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.mockito.InOrder;
 import org.mockito.Mockito;
-import org.mockito.internal.util.MockUtil;
+import static org.mockito.Mockito.mockingDetails;
 
 import com.google.common.collect.FluentIterable;
 
@@ -128,7 +128,7 @@ public final class Mocks<S> {
 
             final Object[] mocks = FluentIterable
                     .from(initParams)
-                    .filter(new MockUtil()::isMock)
+                    .filter(obj -> mockingDetails(obj).isMock())
                     .toArray(Object.class);
 
             @SuppressWarnings("unchecked")


### PR DESCRIPTION
- updates mockito 1 -> 3
- updates Hamcrest 1 -> 2
  * we were using hamcrest-library and hamcrest-core, which
    are now deprecated and moved into a combined hamcrest
    package