### PR TITLE
Fixes api/implementation in build.gradles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ subprojects {
         mavenCentral()
     }
 
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'eclipse'
     apply plugin: 'maven'
 

--- a/just-java-test-toolbox/build.gradle
+++ b/just-java-test-toolbox/build.gradle
@@ -1,10 +1,10 @@
 description 'Just Java Test Toolbox - common java test tools and utilities missing in other tool libraries'
 
 dependencies {
-    implementation 'com.google.guava:guava:23.2-jre'
-    implementation 'joda-time:joda-time:2.9.9'
-    implementation 'org.mockito:mockito-core:3.11.2'
-    implementation 'org.hamcrest:hamcrest:2.2'
+    api 'com.google.guava:guava:23.2-jre'
+    api 'joda-time:joda-time:2.9.9'
+    api 'org.mockito:mockito-core:3.11.2'
+    api 'org.hamcrest:hamcrest:2.2'
 
     implementation project(':just-java-toolbox')
 }

--- a/just-java-toolbox/build.gradle
+++ b/just-java-toolbox/build.gradle
@@ -1,8 +1,8 @@
 description 'Just Java Toolbox - common java tools and utilities missing in other tool libraries'
 
 dependencies {
-    implementation 'com.google.guava:guava:23.2-jre'
+    api 'com.google.guava:guava:23.2-jre'
+    api 'joda-time:joda-time:2.9.9'
     implementation 'com.google.code.findbugs:annotations:3.0.1'
-    implementation 'joda-time:joda-time:2.9.9'
 }
 

--- a/just-kafka-client-toolbox/build.gradle
+++ b/just-kafka-client-toolbox/build.gradle
@@ -1,7 +1,7 @@
 description 'Just Kafka Client Toolbox - common tools and utilities for kafka clients'
 
 dependencies {
-  implementation 'org.apache.kafka:kafka-clients:2.0.1'
+  api 'org.apache.kafka:kafka-clients:2.0.1'
   implementation 'com.google.guava:guava:23.2-jre'
   implementation 'com.google.code.findbugs:annotations:3.0.1'
 

--- a/just-mybatis-toolbox/build.gradle
+++ b/just-mybatis-toolbox/build.gradle
@@ -1,10 +1,10 @@
 description 'Just Java Mybatis Toolbox - common mybatis tools and utilities missing in mybatis library'
 
 dependencies {
-    implementation 'org.mybatis:mybatis:3.5.4'
-    implementation 'com.google.guava:guava:23.2-jre'
+    api 'org.mybatis:mybatis:3.5.4'
+    api 'com.google.guava:guava:23.2-jre'
+    api 'joda-time:joda-time:2.9.9'
     implementation 'com.google.code.findbugs:annotations:3.0.1'
-    implementation 'joda-time:joda-time:2.9.9'
     implementation project(':just-java-toolbox')
 
     testImplementation project(':just-java-test-toolbox')

--- a/just-performance-toolbox/build.gradle
+++ b/just-performance-toolbox/build.gradle
@@ -2,9 +2,9 @@ description 'Just Performance Toolbox - common tools and utilities for performan
 
 dependencies {
     implementation project(':just-java-toolbox')
-    implementation 'org.aspectj:aspectjweaver:1.9.1'
+    api 'org.aspectj:aspectjweaver:1.9.1'
+    api 'joda-time:joda-time:2.9.9'
     implementation 'org.slf4j:slf4j-api:1.7.25'
-    implementation 'joda-time:joda-time:2.9.9'
     implementation 'com.google.guava:guava:23.2-jre'
     implementation 'com.google.code.findbugs:annotations:3.0.1'
 }


### PR DESCRIPTION
After upgrading to Gradle 6, we did not publish a new
version. So we missed, that necessary api dependencies were
only declared as implementation dependencies and would therefore
not be installed to and found in projects using the just-java-toolbox.

-> switches dependencies from "implementation" to "api" where necessary